### PR TITLE
Make area under footer look dark

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -4,7 +4,14 @@
   padding: 0;
 }
 
+html {
+  background-color: #333;
+  width: 100%;
+  height: 100%;
+}
+
 body{
+  width: 100%;
   font-family: Arial, Helvetica, sans-serif;
   line-height: 1.4rem;
   background: #f4f4f4;


### PR DESCRIPTION
Doesn't push footer to bottom of screen, but does make the area that is under the footer darker to blend in more.

![image](https://user-images.githubusercontent.com/5248800/52450524-46366b80-2af0-11e9-8af6-a38aada347c7.png)
