### PR TITLE
Make TwoMean dots stack

### DIFF
--- a/src/twoMean/twoMean.js
+++ b/src/twoMean/twoMean.js
@@ -20,7 +20,9 @@ export class TwoMean {
     this.dataChart1 = new StackedDotChart(twoMeanDiv.querySelector('#data-chart-1'), [this.datasets[0]]);
     this.dataChart2 = new StackedDotChart(twoMeanDiv.querySelector('#data-chart-2'), [this.datasets[1]]);
     this.sampleChart1 = new StackedDotChart(twoMeanDiv.querySelector('#sample-chart-1'), this.datasets);
+    this.sampleChart1.chart.options.legend.display = false;
     this.sampleChart2 = new StackedDotChart(twoMeanDiv.querySelector('#sample-chart-2'), this.datasets);
+    this.sampleChart2.chart.options.legend.display = false;
     this.diffChart = new StackedDotChart(twoMeanDiv.querySelector('#diff-chart'), [
       { label: 'Diff of Means', backgroundColor: '#333333', data: [], },
     ]);
@@ -69,6 +71,10 @@ export class TwoMean {
       this.dataChart2.setScale(min, max);
       this.sampleChart1.setScale(min, max);
       this.sampleChart2.setScale(min, max);
+      this.dataChart1.scaleToStackDots();
+      this.dataChart2.scaleToStackDots();
+      this.sampleChart1.scaleToStackDots();
+      this.sampleChart2.scaleToStackDots();
     }
     this.dataChart1.chart.update();
     this.dataChart2.chart.update();
@@ -164,6 +170,7 @@ export class TwoMean {
         ? MathUtil.roundToPlaces((datasetDiffOfMeans - sampleDiffMean) / sampleDiffStdDev, 2)
         : '___';
     this.diffChart.setDataFromRaw([this.sampleDiffs]);
+    this.diffChart.scaleToStackDots();
     this.diffChart.chart.update();
   }
 }

--- a/src/util/stackeddotchart.js
+++ b/src/util/stackeddotchart.js
@@ -67,11 +67,35 @@ export default class StackedDotChart {
       }
     }
     this.chart.options.scales.yAxes[0].ticks.stepSize = Math.pow(10, Math.floor(Math.log10(max)));
+
   }
 
   setScale(start, end) {
     this.chart.options.scales.xAxes[0].ticks.min = start;
     this.chart.options.scales.xAxes[0].ticks.max = end;
+  }
+
+  /**
+   * Attempts to scale y dimension to make the dots stack directly on top of
+   * each other. If there is not enough space in the chart to do so, the y will
+   * scale to contain all the dots, squishing them to clip into each other.
+   * When there are many dots, this makes the stack look like a vertical bar.
+   */
+  scaleToStackDots() {
+    // TODO(matthewmerrill): memoize getMax with a dirty flag
+    let max = 1;
+    for (let dataset of this.chart.data.datasets) {
+      console.log(dataset);
+      for (let item of dataset.data) {
+        max = Math.max(max, item.y);
+      }
+    }
+    let {top, bottom} = this.chart.chartArea;
+    let chartHeight = bottom - top;
+    let pointRadius = this.chart.data.datasets[0].pointRadius;
+    this.chart.options.scales.yAxes[0].ticks.max = Math.max(
+      max,
+      this.chart.options.scales.yAxes[0].ticks.min + (chartHeight/pointRadius * .5));
   }
 
   updateLabelName(datasetIndex, labelName) {


### PR DESCRIPTION
Adds method StackedDotChart#scaleToMakeDotsStack that scales the y
dimension to force the dots to stack directly on top of each other
rather than spreading throughout the chart.