### PR TITLE
Translation support

### DIFF
--- a/src/_data/translate.yml
+++ b/src/_data/translate.yml
@@ -1,0 +1,7 @@
+en:
+  oneProportion:
+    title: 'One Proportion'
+
+sp:
+  oneProportion:
+    title: 'Una Proporción'

--- a/src/_data/translate.yml
+++ b/src/_data/translate.yml
@@ -2,6 +2,6 @@ en:
   oneProportion:
     title: 'One Proportion'
 
-sp:
+es:
   oneProportion:
     title: 'Una Proporción'

--- a/src/_includes/translate.html
+++ b/src/_includes/translate.html
@@ -1,5 +1,5 @@
-{%   if jekyll.environment == "sp"
-%}{%   assign lang="sp"
+{%   if jekyll.environment == "es"
+%}{%   assign lang="es"
 %}{% else
 %}{%   assign lang="en"
 %}{% endif

--- a/src/_includes/translate.html
+++ b/src/_includes/translate.html
@@ -1,0 +1,10 @@
+{%   if jekyll.environment == "sp"
+%}{%   assign lang="sp"
+%}{% else
+%}{%   assign lang="en"
+%}{% endif
+%}{% assign node = site.data.translate[lang]
+%}{% assign key_path = include.key | split: '.'
+%}{% for key_seg in key_path
+%}{%   assign node = node[key_seg]
+%}{% endfor %}{{ node }}

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@ title: Home
 <link rel="stylesheet" href="/css/home.css">
 <div id="main-menu">
   <ul>
-    <li><a href="/oneProportion/" class="btn">One Proportion</a></li>
+    <li><a href="/oneProportion/" class="btn">{% include translate.html key="oneProportion.title" %}</a></li>
     <li><a href="/twoProportions/" class="btn">Two Proportions</a></li>
     <li><a href="/oneMean/" class="btn">One Mean</a></li>
     <li><a href="/twoMean/" class="btn">Two Means</a></li>


### PR DESCRIPTION
In any file processed by jekyll, use `{% include translate.html key="the.key.path" %}` to replace the string identified by the key `the.key.path`.

Build the spanish version of the site using: `JEKYLL_ENV=es jekyll build`