### PR TITLE
Add Buckets to StackedDotCharts, Summaries toFixed

### DIFF
--- a/src/twoMean/twoMean.js
+++ b/src/twoMean/twoMean.js
@@ -92,11 +92,6 @@ export class TwoMean {
     this.data[1] = this.data[1] || [];
     this.sampleDiffs = [];
 
-    this.dataChart1.setDataFromRaw([data[0]]);
-    this.dataChart2.setDataFromRaw([data[1]]);
-    this.sampleChart1.clear();
-    this.sampleChart2.clear();
-
     let dataValues = data[0].concat(data[1]);
     if (dataValues.length) {
       let min = Math.min.apply(undefined, dataValues);
@@ -105,11 +100,18 @@ export class TwoMean {
       this.dataChart2.setScale(min, max);
       this.sampleChart1.setScale(min, max);
       this.sampleChart2.setScale(min, max);
-      this.dataChart1.scaleToStackDots();
-      this.dataChart2.scaleToStackDots();
-      this.sampleChart1.scaleToStackDots();
-      this.sampleChart2.scaleToStackDots();
     }
+
+    this.dataChart1.setDataFromRaw([data[0]]);
+    this.dataChart2.setDataFromRaw([data[1]]);
+    this.sampleChart1.clear();
+    this.sampleChart2.clear();
+
+    this.dataChart1.scaleToStackDots();
+    this.dataChart2.scaleToStackDots();
+    this.sampleChart1.scaleToStackDots();
+    this.sampleChart2.scaleToStackDots();
+
     this.dataChart1.chart.update();
     this.dataChart2.chart.update();
     this.sampleChart1.chart.update();

--- a/src/util/stackeddotchart.js
+++ b/src/util/stackeddotchart.js
@@ -2,7 +2,7 @@
 //import Chart from "chart.js";
 
 export default class StackedDotChart {
-  constructor(domElement, datasets) {
+  constructor(domElement, datasets, options) {
     this.domElement = domElement;
     this.datasets = [];
     for (let dataset of datasets) {
@@ -33,6 +33,35 @@ export default class StackedDotChart {
         maintainAspectRatio: false
       }
     });
+    options = options || {};
+    this.options = {
+      autoBuckets: options.autoBuckets !== undefined ? options.autoBuckets : true,
+      bucketWidth: options.bucketWidth,
+    };
+  }
+
+  round(x, bucketSize) {
+    if (bucketSize == undefined) {
+      if (this.options.autoBuckets) {
+        let scale = this.chart.scales['x-axis-1'];
+        let inScaleWidth = scale.options.ticks.max - scale.options.ticks.min;
+        let chartWidth = this.chart.width;
+        let pointRadius = this.chart.data.datasets[0].pointRadius;
+        bucketSize = 2 * pointRadius * (inScaleWidth / chartWidth);
+      }
+      else if (this.options.bucketWidth) {
+        bucketSize = this.bucketWidth;
+      }
+    }
+    if (bucketSize) {
+      console.log(bucketSize);
+      let r = Math.floor(x / bucketSize) * bucketSize;
+      console.log(x, r);
+      return r;
+    }
+    else {
+      return x;
+    }
   }
 
   rawToScatter(arrs) {
@@ -41,6 +70,7 @@ export default class StackedDotChart {
     for (let arr of arrs) {
       let scatter = [];
       for (let item of arr) {
+        item = this.round(item);
         let y = (counts[item] = (counts[item] || 0) + 1);
         scatter.push({ x: item, y: y });
       }

--- a/src/util/summaries.js
+++ b/src/util/summaries.js
@@ -17,6 +17,9 @@ export function updateSummaryElements(summaryElements, state) {
     let elems = summaryElements[key];
     if (elems) {
       for (let summaryElem of elems) {
+        if (typeof value === 'number') {
+          value = value.toFixed(4);
+        }
         summaryElem.innerText = value + '';
       }
     }

--- a/src/util/tailchart.js
+++ b/src/util/tailchart.js
@@ -117,6 +117,8 @@ export default class TailChart {
 
   updateChart() {
     let valuesArr = this.results;
+    let min = Math.min.apply(undefined, valuesArr);
+    let max = Math.max.apply(undefined, valuesArr);
     const mean = MathUtil.roundToPlaces(MathUtil.mean(this.results), 2);
     const { chosen, unchosen } = splitByPredicate(
       valuesArr,
@@ -124,6 +126,7 @@ export default class TailChart {
     );
     // todo(matthewmerrill): if used for onemean, this isn't 0
     this.updateChartLabels(0);
+    this.chart.setScale(min, max);
     this.chart.setDataFromRaw([unchosen, chosen]);
     this.chart.scaleToStackDots();
     // update(0) disables animations. This prevents dots moving around confusingly.


### PR DESCRIPTION
Options available for fixed bucket sizes and disabling bucket
functionality on stackeddotcharts.

Summaries now toFixed(4) all number types displayed.